### PR TITLE
feat/static-page-creation

### DIFF
--- a/blueprints/course.py
+++ b/blueprints/course.py
@@ -88,7 +88,6 @@ def course_create_new_page(course_url: str):
         page_dictionary = dict(request.form)
 
         try:
-            # TODO add more robust validation/conversion into Page model
             page_to_insert = Page(**page_dictionary)
             content_repo = get_content_repository()
             page_to_insert.page_id = content_repo.add_new_page_and_get_id(page_to_insert)

--- a/blueprints/course.py
+++ b/blueprints/course.py
@@ -127,3 +127,8 @@ def course_custom_static_url_edit_page(course_url: str, custom_static_path: str)
     # TODO render edit page
     return f"Edit page for static path for {course_url}: {custom_static_path}"
 
+@course_bp.route("/<string:course_url>/new/", methods=["GET", "POST"])
+def course_new_page(course_url: str):
+    # Should fully expect all values in form to be strings
+    return f"New page UI"
+

--- a/blueprints/course.py
+++ b/blueprints/course.py
@@ -99,6 +99,9 @@ def course_create_new_page(course_url: str):
             return "ValueError", 400
         except AlreadyExistsException as e:
             return "AlreadyExistsException", 400
+        except TypeError:
+            # Something happened when constructing the Page object
+            return "TypeError", 400
 
 @course_bp.route("/<string:course_url>/", methods=["GET"])
 def course_home_page(course_url: str):

--- a/blueprints/course.py
+++ b/blueprints/course.py
@@ -5,6 +5,7 @@ import markdown2
 from bs4 import BeautifulSoup
 from flask import Blueprint, render_template, session, abort, request, redirect
 
+from custom_exceptions import AlreadyExistsException
 from flask_helpers import get_user_from_session
 from flask_repository_getters import get_course_repository, get_user_repository, get_content_repository
 from models.course import Course
@@ -96,6 +97,8 @@ def course_create_new_page(course_url: str):
         except ValueError as e:
             # TODO return the user to the same page, but with error
             return "ValueError", 400
+        except AlreadyExistsException as e:
+            return "AlreadyExistsException", 400
 
 @course_bp.route("/<string:course_url>/", methods=["GET"])
 def course_home_page(course_url: str):

--- a/blueprints/course.py
+++ b/blueprints/course.py
@@ -94,17 +94,37 @@ def course_create_new_page(course_url: str):
             page_to_insert.page_id = content_repo.add_new_page_and_get_id(page_to_insert)
 
             return redirect(course.starting_url_path + page_to_insert.url_path_after_course_path)
+
+        # TODO create test cases for each error type
+        # TODO PLEASE give better error messages, these are super vague right now
         except ValueError as e:
-            # TODO return the user to the same page, but with error
             current_app.logger.exception(e)
-            return "ValueError", 400
+            return render_template(
+                "course_edit_page.html",
+                user=user,
+                role=role,
+                course=course,
+                error="Couldn't convert one of the attributes into the correct type."
+            ), 400
         except AlreadyExistsException as e:
             current_app.logger.exception(e)
-            return "AlreadyExistsException", 400
+            return render_template(
+                "course_edit_page.html",
+                user=user,
+                role=role,
+                course=course,
+                error="There is already a page with that URL in this course. Please try again with a different URL."
+            ), 400
         except TypeError as e:
             # Something happened when constructing the Page object
             current_app.logger.exception(e)
-            return "TypeError", 400
+            return render_template(
+                "course_edit_page.html",
+                user=user,
+                role=role,
+                course=course,
+                error="There was an issue parsing your response. Please try again later."
+            ), 400
 
 @course_bp.route("/<string:course_url>/", methods=["GET"])
 def course_home_page(course_url: str):

--- a/blueprints/course.py
+++ b/blueprints/course.py
@@ -3,7 +3,7 @@ import urllib.parse
 
 import markdown2
 from bs4 import BeautifulSoup
-from flask import Blueprint, render_template, session, abort, request, redirect
+from flask import Blueprint, render_template, session, abort, request, redirect, current_app
 
 from custom_exceptions import AlreadyExistsException
 from flask_helpers import get_user_from_session
@@ -96,11 +96,14 @@ def course_create_new_page(course_url: str):
             return redirect(course.starting_url_path + page_to_insert.url_path_after_course_path)
         except ValueError as e:
             # TODO return the user to the same page, but with error
+            current_app.logger.exception(e)
             return "ValueError", 400
         except AlreadyExistsException as e:
+            current_app.logger.exception(e)
             return "AlreadyExistsException", 400
-        except TypeError:
+        except TypeError as e:
             # Something happened when constructing the Page object
+            current_app.logger.exception(e)
             return "TypeError", 400
 
 @course_bp.route("/<string:course_url>/", methods=["GET"])

--- a/models/page.py
+++ b/models/page.py
@@ -23,6 +23,7 @@ class Page:
     page_id: Optional[int] = None
 
     def __post_init__(self):
+        # TODO add URL validation
         # Attempt to auto-convert, and throws an obvious error if it fails
         if not isinstance(self.page_visibility_setting, VisibilitySetting):
             self.page_visibility_setting = VisibilitySetting(int(self.page_visibility_setting))

--- a/models/page.py
+++ b/models/page.py
@@ -23,5 +23,15 @@ class Page:
     page_id: Optional[int] = None
 
     def __post_init__(self):
-        if isinstance(self.page_visibility_setting, int):
-            self.page_visibility_setting = VisibilitySetting(self.page_visibility_setting)
+        # Attempt to auto-convert, and throws an obvious error if it fails
+        if not isinstance(self.page_visibility_setting, VisibilitySetting):
+            self.page_visibility_setting = VisibilitySetting(int(self.page_visibility_setting))
+
+        if not isinstance(self.course_id, int):
+            self.course_id = int(self.course_id)
+
+        if self.created_by_user_id and not isinstance(self.created_by_user_id, int):
+            self.created_by_user_id = int(self.created_by_user_id)
+
+        if self.page_id and not isinstance(self.page_id, int):
+            self.page_id = int(self.page_id)

--- a/templates/course_edit_page.html
+++ b/templates/course_edit_page.html
@@ -1,0 +1,123 @@
+{% extends "course_layout.html" %}
+{% block header %}
+    {{ super() }}
+    <style>
+        .top-navigation-bar {
+            display: none;
+        }
+
+        .portrait-nav {
+            display: none;
+        }
+
+        .grow-wrap {
+            /* easy way to plop the elements on top of each other and have them both sized based on the tallest one's height */
+            display: grid;
+        }
+
+        .grow-wrap::after {
+            /* Note the weird space! Needed to prevent jumpy behavior */
+            content: attr(data-replicated-value) " ";
+            /* This is how textarea text behaves */
+            white-space: pre-wrap;
+            /* Hidden from view, clicks, and screen readers */
+            visibility: hidden;
+        }
+
+        .grow-wrap>textarea {
+            /* You could leave this, but after a user resizes, then it ruins the auto sizing */
+            resize: none;
+            /* Firefox shows scrollbar on growth, you can hide like this. */
+            overflow: hidden;
+
+            min-height: 16em;
+        }
+
+        .grow-wrap>textarea,
+        .grow-wrap::after {
+            /* Identical styling required!! */
+            border: 1px solid black;
+            padding: 0.5rem;
+            font: inherit;
+            /* Place on top of each other */
+            grid-area: 1 / 1 / 2 / 2;
+        }
+
+        .main-wrapper {
+            display: flex;
+            flex-direction: column;
+            width: 100%;
+        }
+
+        .edit-button-group {
+            display: flex;
+            flex-direction: row;
+            gap: 1em;
+            padding: 0 1em;
+        }
+
+        .additional-attributes {
+            display: flex;
+            flex-direction: column;
+            gap: 8px;
+        }
+
+        .additional-attributes-input-group {
+            display: flex;
+            flex-direction: column;
+        }
+
+        .limited-width {
+            max-width: 16em;
+        }
+    </style>
+{% endblock %}
+{% block body %}
+    {{ super() }}
+    <form
+        class="main-wrapper"
+        method="POST"
+        action="{{ course.starting_url_path }}/new"
+        enctype="multipart/form-data"
+    >
+        <div class="bar-above-main-content edit-bar">
+            <div class="edit-button-group">
+                <button>Discard</button>
+                <button type="submit">Save</button>
+            </div>
+        </div>
+        <main>
+            <div class="additional-attributes">
+                <div class="additional-attributes-input-group limited-width">
+                    <label for="page_title">Title</label>
+                    <input id="page_title" name="page_title" type="text" required >
+                </div>
+                <div class="additional-attributes-input-group limited-width">
+                    <label for="url_path_after_course_path">URL path</label>
+                    <input
+                        id="url_path_after_course_path"
+                        name="url_path_after_course_path"
+                        type="text"
+                        placeholder="e.g. /office-hours"
+                        required
+                    >
+                </div>
+                <div class="additional-attributes-input-group limited-width">
+                    <label for="page_visibility_setting">Visibility</label>
+                    <select id="page_visibility_setting" name="page_visibility_setting" required>
+                        <option value="2">Listed</option>
+                        <option value="1">Unlisted</option>
+                        <option value="0">Hidden</option>
+                    </select>
+                </div>
+                <div class="additional-attributes-input-group">
+                    <label for="page_content">Content</label>
+                    <div class="grow-wrap">
+                        <textarea name="page_content" id="page_content" onInput="this.parentNode.dataset.replicatedValue = this.value"></textarea>
+                    </div>
+                </div>
+            </div>
+        </main>
+    </form>
+{% endblock %}
+

--- a/templates/course_edit_page.html
+++ b/templates/course_edit_page.html
@@ -70,6 +70,11 @@
         .limited-width {
             max-width: 16em;
         }
+
+        .hidden-attributes {
+            width: 0;
+            height: 0;
+        }
     </style>
 {% endblock %}
 {% block body %}
@@ -87,6 +92,11 @@
             </div>
         </div>
         <main>
+            <div class="hidden-attributes">
+                {# Needed for the form, but hidden to the user #}
+                <label for="course_id"></label>
+                <input id="course_id" name="course_id" type="hidden" value="{{ course.course_id }}" >
+            </div>
             <div class="additional-attributes">
                 <div class="additional-attributes-input-group limited-width">
                     <label for="page_title">Title</label>

--- a/templates/course_edit_page.html
+++ b/templates/course_edit_page.html
@@ -92,6 +92,7 @@
             </div>
         </div>
         <main>
+            <p class="error-text">{{ error }}</p>
             <div class="hidden-attributes">
                 {# Needed for the form, but hidden to the user #}
                 <label for="course_id"></label>

--- a/templates/course_layout.html
+++ b/templates/course_layout.html
@@ -176,6 +176,12 @@
         <p class="footer">
             Signed in as {{ user.full_name }} ({{ user.email }})
             <br>
+            {% if role.value == 2 or role.value == 3 %}
+                <a href="{{ course.starting_url_path }}/new">
+                    [New page]
+                </a>
+                <br>
+            {% endif %}
             <a href="/">
                 [View all classes]
             </a>
@@ -228,6 +234,12 @@
             <p class="footer">
                 Signed in as {{ user.full_name }} ({{ user.email }})
                 <br>
+                {% if role.value == 2 or role.value == 3 %}
+                    <a href="{{ course.starting_url_path }}/new">
+                        [New page]
+                    </a>
+                    <br>
+                {% endif %}
                 <a href="/">
                     [View all classes]
                 </a>

--- a/test/blueprints/test_course_blueprint.py
+++ b/test/blueprints/test_course_blueprint.py
@@ -415,9 +415,44 @@ This is the home page.
 
 
     def test_new_page_submission_for_different_roles(self):
-        # expected: page exists in DB and user directed to new page
-        # for students, 401 error
-        pass
+        # TODO move role testing into method which takes callback?
+        user, _ = self.add_sample_user_to_test_db()
+        courses, course_terms = self.add_sample_course_term_and_course_cluster()
+        course = courses[0]
+
+        # Note that values are passed as strings in form
+        # even when defined as ints here
+        sample_page_dictionary = {
+            "page_title": "Office Hours",
+            "page_content": self.static_page_content_for_testing,
+            "page_visibility_setting": VisibilitySetting.LISTED.value,
+            "course_id": course.course_id,
+            "url_path_after_course_path": "/office-hours"
+        }
+        page_to_assert_against = Page(**sample_page_dictionary)
+
+        self.sign_user_into_session(user)
+
+        roles = list(Role)
+        for role in roles:
+            with self.subTest(role=role):
+                enrollment = CourseEnrollment(
+                    user_id=user.user_id,
+                    course_id=course.course_id,
+                    role=role
+                )
+                self.add_single_enrollment(enrollment)
+
+                response = self.test_client.post(course.starting_url_path + "/new/", data=sample_page_dictionary)
+                if role == Role.STUDENT:
+                    self.assertEqual(response.status_code, 401)
+                    self.assert_single_page_does_not_exist_by_id(page_to_assert_against)
+                else:
+                    # Should redirect to the new page
+                    self.assertEqual(response.status_code, 302)
+                    self.assert_single_page_against_matching_id_page_in_db(page_to_assert_against)
+
+            self.clear_all_enrollments()
 
     def test_new_page_submission_with_conflicting_url(self):
         # expected: 400 error

--- a/test/blueprints/test_course_blueprint.py
+++ b/test/blueprints/test_course_blueprint.py
@@ -389,3 +389,20 @@ This is the home page.
                     # TODO write assertions
 
             self.clear_all_enrollments()
+
+    def test_new_page_submission_for_different_roles(self):
+        # expected: page exists in DB and user directed to new page
+        # for students, 401 error
+        pass
+
+    def test_new_page_submission_with_conflicting_url(self):
+        # expected: 400 error
+        pass
+
+    def test_new_page_submission_with_id(self):
+        # expected: 400 error
+        pass
+
+    def test_new_page_submission_with_missing_data(self):
+        # expected: 400 error
+        pass

--- a/test/blueprints/test_course_blueprint.py
+++ b/test/blueprints/test_course_blueprint.py
@@ -2,7 +2,7 @@ import re
 from typing import Optional
 
 from bs4 import BeautifulSoup
-from flask import Response, session
+from flask import Response
 
 from models.course import Course
 from models.course_enrollment import CourseEnrollment, Role
@@ -100,12 +100,7 @@ This is the home page.
                 response = self.test_client.get(course.starting_url_path + "/")
                 self.assert_course_layout_content(response, course, user, role)
 
-            delete_query = '''
-            DELETE FROM enrollment;
-            '''
-            cursor = self.connection.cursor()
-            cursor.execute(delete_query)
-            self.connection.commit()
+            self.clear_all_enrollments()
 
     def test_course_home_page_content_with_relative_urls(self):
         user, _ = self.add_sample_user_to_test_db()

--- a/test/blueprints/test_course_blueprint.py
+++ b/test/blueprints/test_course_blueprint.py
@@ -86,10 +86,10 @@ This is the home page.
         full_name_text = soup.find(string=re.compile(user.full_name))
         self.assertIsNotNone(full_name_text)
 
-        new_page_button = soup.find(string=re.compile("new page", re.IGNORECASE))
+        new_page_button = soup.find("a", string=re.compile("new page", re.IGNORECASE))
         if role and (role == Role.ASSISTANT or role == Role.PROFESSOR):
             self.assertIsNotNone(new_page_button)
-            self.assertEqual(new_page_button.attrs["href"], "/new")
+            self.assertEqual(new_page_button.attrs["href"], f"{course.starting_url_path}/new")
         else:
             self.assertIsNone(new_page_button)
 

--- a/test/blueprints/test_course_blueprint.py
+++ b/test/blueprints/test_course_blueprint.py
@@ -530,5 +530,34 @@ This is the home page.
             self.clear_all_enrollments()
 
     def test_new_page_submission_with_missing_data(self):
-        # expected: 400 error
-        pass
+        user, _ = self.add_sample_user_to_test_db()
+        courses, course_terms = self.add_sample_course_term_and_course_cluster()
+        course = courses[0]
+
+        sample_page_dictionary = self.generate_sample_page_dictionary(course)
+        page_to_assert_against = Page(**sample_page_dictionary)
+        sample_page_dictionary["page_title"] = None
+        # TODO test other data types after refactoring
+
+        self.sign_user_into_session(user)
+
+        roles = list(Role)
+        for role in roles:
+            with self.subTest(role=role):
+                enrollment = CourseEnrollment(
+                    user_id=user.user_id,
+                    course_id=course.course_id,
+                    role=role
+                )
+                self.add_single_enrollment(enrollment)
+
+                response = self.test_client.post(course.starting_url_path + "/new/", data=sample_page_dictionary)
+
+                if role == Role.STUDENT:
+                    self.assertEqual(response.status_code, 401)
+                else:
+                    self.assertEqual(response.status_code, 400)
+
+                self.assert_single_page_does_not_exist_by_course_id_and_url(page_to_assert_against)
+
+            self.clear_all_enrollments()

--- a/test/blueprints/test_course_blueprint.py
+++ b/test/blueprints/test_course_blueprint.py
@@ -56,6 +56,36 @@ This is the home page.
         else:
             self.assertIsNone(new_page_button)
 
+    def assert_edit_page_content(self, response):
+        soup = BeautifulSoup(response.data, "html.parser")
+
+        title_input = soup.find("input", id="title")
+        self.assertIsNotNone(title_input)
+        self.assertIn("required", title_input.attrs)
+
+        url_input = soup.find("input", id="url")
+        self.assertIsNotNone(url_input)
+        self.assertIn("required", url_input.attrs)
+
+        visibility_select = soup.find("select", id="visibility")
+        self.assertIsNotNone(visibility_select)
+        self.assertIn("required", visibility_select.attrs)
+
+        options = visibility_select.find_all("option")
+        self.assertEqual(len(options), 3)
+        self.assertEqual(options[0].attrs["value"], "2")
+        self.assertEqual(options[0].string, "Listed")
+        self.assertEqual(options[1].attrs["value"], "1")
+        self.assertEqual(options[1].string, "Unlisted")
+        self.assertEqual(options[2].attrs["value"], "0")
+        self.assertEqual(options[2].string, "Hidden")
+
+        content_textarea = soup.find("textarea", id="content")
+        self.assertIsNotNone(content_textarea)
+
+        submit_button = soup.find("button", type="submit")
+        self.assertIsNotNone(submit_button)
+
     def assert_static_page_main_content(self, response):
         soup = BeautifulSoup(response.data, "html.parser")
         soup = soup.main
@@ -379,36 +409,10 @@ This is the home page.
                     self.assertEqual(response.status_code, 401)
                 else:
                     self.assertEqual(response.status_code, 200)
-                    soup = BeautifulSoup(response.data, "html.parser")
-
-                    title_input = soup.find("input", id="title")
-                    self.assertIsNotNone(title_input)
-                    self.assertIn("required", title_input.attrs)
-
-                    url_input = soup.find("input", id="url")
-                    self.assertIsNotNone(url_input)
-                    self.assertIn("required", url_input.attrs)
-
-                    visibility_select = soup.find("select", id="visibility")
-                    self.assertIsNotNone(visibility_select)
-                    self.assertIn("required", visibility_select.attrs)
-
-                    options = visibility_select.find_all("option")
-                    self.assertEqual(len(options), 3)
-                    self.assertEqual(options[0].attrs["value"], "2")
-                    self.assertEqual(options[0].string, "Listed")
-                    self.assertEqual(options[1].attrs["value"], "1")
-                    self.assertEqual(options[1].string, "Unlisted")
-                    self.assertEqual(options[2].attrs["value"], "0")
-                    self.assertEqual(options[2].string, "Hidden")
-
-                    content_textarea = soup.find("textarea", id="content")
-                    self.assertIsNotNone(content_textarea)
-
-                    submit_button = soup.find("button", type="submit")
-                    self.assertIsNotNone(submit_button)
+                    self.assert_edit_page_content(response)
 
             self.clear_all_enrollments()
+
 
     def test_new_page_submission_for_different_roles(self):
         # expected: page exists in DB and user directed to new page

--- a/test/blueprints/test_course_blueprint.py
+++ b/test/blueprints/test_course_blueprint.py
@@ -501,7 +501,6 @@ This is the home page.
             user=user,
             course=course,
             callback=assertion_callback,
-            cleanup_callbacks=[self.clear_all_pages]
         )
 
     def test_new_page_submission_with_id(self):
@@ -526,7 +525,6 @@ This is the home page.
             user=user,
             course=course,
             callback=assertion_callback,
-            cleanup_callbacks=[self.clear_all_pages]
         )
 
 
@@ -554,5 +552,4 @@ This is the home page.
                     user=user,
                     course=course,
                     callback=assertion_callback,
-                    cleanup_callbacks=[self.clear_all_pages]
                 )

--- a/test/blueprints/test_course_blueprint.py
+++ b/test/blueprints/test_course_blueprint.py
@@ -51,7 +51,7 @@ This is the home page.
             "url_path_after_course_path": "/office-hours"
         }
 
-    def execute_assertions_callback_based_on_roles_and_enrollment(self, user: User, course: Course, callback):
+    def execute_assertions_callback_based_on_roles_and_enrollment(self, user: User, course: Course, callback, cleanup_callbacks = []):
         roles = list(Role)
         for role in roles:
             with self.subTest(role=role):
@@ -65,6 +65,9 @@ This is the home page.
                 callback(role)
 
             self.clear_all_enrollments()
+
+            for cleanup_callback in cleanup_callbacks:
+                cleanup_callback()
 
     def assert_course_layout_content(self, response: Response, course: Course, user: User, role: Optional[Role] = None):
         # Check reused layout content for the course
@@ -460,12 +463,13 @@ This is the home page.
             else:
                 # Should redirect to the new page
                 self.assertEqual(response.status_code, 302)
-                self.assert_single_page_against_matching_course_id_and_url_in_db(page_to_assert_against)
+                self.assert_single_page_against_matching_course_id_and_url_in_db(page_to_assert_against, should_check_page_id=False)
 
         self.execute_assertions_callback_based_on_roles_and_enrollment(
             user=user,
             course=course,
             callback=assertion_callback,
+            cleanup_callbacks=[self.clear_all_pages]
         )
 
     def test_new_page_submission_with_conflicting_url(self):
@@ -497,6 +501,7 @@ This is the home page.
             user=user,
             course=course,
             callback=assertion_callback,
+            cleanup_callbacks=[self.clear_all_pages]
         )
 
     def test_new_page_submission_with_id(self):
@@ -521,6 +526,7 @@ This is the home page.
             user=user,
             course=course,
             callback=assertion_callback,
+            cleanup_callbacks=[self.clear_all_pages]
         )
 
 
@@ -548,4 +554,5 @@ This is the home page.
                     user=user,
                     course=course,
                     callback=assertion_callback,
+                    cleanup_callbacks=[self.clear_all_pages]
                 )

--- a/test/blueprints/test_course_blueprint.py
+++ b/test/blueprints/test_course_blueprint.py
@@ -427,10 +427,10 @@ This is the home page.
 
         def assertion_callback(role: Role):
             response = self.test_client.get(course.starting_url_path + "/new/")
-            self.assert_course_layout_content(response, course, user, role)
             if role == Role.STUDENT:
                 self.assertEqual(response.status_code, 401)
             else:
+                self.assert_course_layout_content(response, course, user, role)
                 self.assertEqual(response.status_code, 200)
                 self.assert_edit_page_content(response)
 

--- a/test/blueprints/test_course_blueprint.py
+++ b/test/blueprints/test_course_blueprint.py
@@ -524,26 +524,28 @@ This is the home page.
         )
 
 
-    def test_new_page_submission_with_missing_data(self):
+    def test_new_page_submission_with_missing_required_data(self):
         user, _ = self.add_sample_user_to_test_db()
         courses, course_terms = self.add_sample_course_term_and_course_cluster()
         course = courses[0]
 
         sample_page_dictionary = self.generate_sample_page_dictionary(course)
         page_to_assert_against = Page(**sample_page_dictionary)
-        sample_page_dictionary["page_title"] = None
-        # TODO test other data types after refactoring
 
         self.sign_user_into_session(user)
 
-        assertion_callback = self.generate_nonexistence_assertion_callback(
-            course=course,
-            page_to_assert_against=page_to_assert_against,
-            page_dictionary=sample_page_dictionary,
-        )
-        self.execute_assertions_callback_based_on_roles_and_enrollment(
-            user=user,
-            course=course,
-            callback=assertion_callback,
-        )
+        required_data_types = ["page_title", "course_id", "url_path_after_course_path", "page_visibility_setting"]
+        for required_data_type in required_data_types:
+            with self.subTest(required_data_type=required_data_type):
+                sample_page_dictionary[required_data_type] = None
 
+                assertion_callback = self.generate_nonexistence_assertion_callback(
+                    course=course,
+                    page_to_assert_against=page_to_assert_against,
+                    page_dictionary=sample_page_dictionary,
+                )
+                self.execute_assertions_callback_based_on_roles_and_enrollment(
+                    user=user,
+                    course=course,
+                    callback=assertion_callback,
+                )

--- a/test/blueprints/test_course_blueprint.py
+++ b/test/blueprints/test_course_blueprint.py
@@ -355,3 +355,37 @@ This is the home page.
         self.assert_course_layout_content(response, course, user)
 
         self.assert_static_page_content_with_links(course, response)
+
+    def test_new_page_rendering_for_different_roles(self):
+        user, _ = self.add_sample_user_to_test_db()
+        courses, course_terms = self.add_sample_course_term_and_course_cluster()
+        course = courses[0]
+
+        self.sign_user_into_session(user)
+
+        roles = list(Role)
+        for role in roles:
+            with self.subTest(role=role):
+                enrollment = CourseEnrollment(
+                    user_id=user.user_id,
+                    course_id=course.course_id,
+                    role=role
+                )
+                self.add_single_enrollment(enrollment)
+
+                response = self.test_client.get(course.starting_url_path + "/new/")
+                self.assert_course_layout_content(response, course, user, role)
+                if role == Role.STUDENT:
+                    self.assertEqual(response.status_code, 401)
+                else:
+                    soup = BeautifulSoup(response.data, "html.parser")
+                    # Assert there is a button to submit the new page as a form
+                    # Assert there is a textarea to input Markdown content
+                    # Assert that there is input for:
+                    # - the URL path (text input)
+                    # - the visibility (<select> dropdown)
+                    # - the title (text input)
+                    # - the content
+                    # TODO write assertions
+
+            self.clear_all_enrollments()

--- a/test/blueprints/test_course_blueprint.py
+++ b/test/blueprints/test_course_blueprint.py
@@ -96,15 +96,15 @@ This is the home page.
     def assert_edit_page_content(self, response):
         soup = BeautifulSoup(response.data, "html.parser")
 
-        title_input = soup.find("input", id="title")
+        title_input = soup.find("input", id="page_title")
         self.assertIsNotNone(title_input)
         self.assertIn("required", title_input.attrs)
 
-        url_input = soup.find("input", id="url")
+        url_input = soup.find("input", id="url_path_after_course_path")
         self.assertIsNotNone(url_input)
         self.assertIn("required", url_input.attrs)
 
-        visibility_select = soup.find("select", id="visibility")
+        visibility_select = soup.find("select", id="page_visibility_setting")
         self.assertIsNotNone(visibility_select)
         self.assertIn("required", visibility_select.attrs)
 
@@ -117,7 +117,7 @@ This is the home page.
         self.assertEqual(options[2].attrs["value"], "0")
         self.assertEqual(options[2].string, "Hidden")
 
-        content_textarea = soup.find("textarea", id="content")
+        content_textarea = soup.find("textarea", id="page_content")
         self.assertIsNotNone(content_textarea)
 
         submit_button = soup.find("button", type="submit")

--- a/test/blueprints/test_course_blueprint.py
+++ b/test/blueprints/test_course_blueprint.py
@@ -378,15 +378,35 @@ This is the home page.
                 if role == Role.STUDENT:
                     self.assertEqual(response.status_code, 401)
                 else:
+                    self.assertEqual(response.status_code, 200)
                     soup = BeautifulSoup(response.data, "html.parser")
-                    # Assert there is a button to submit the new page as a form
-                    # Assert there is a textarea to input Markdown content
-                    # Assert that there is input for:
-                    # - the URL path (text input)
-                    # - the visibility (<select> dropdown)
-                    # - the title (text input)
-                    # - the content
-                    # TODO write assertions
+
+                    title_input = soup.find("input", id="title")
+                    self.assertIsNotNone(title_input)
+                    self.assertIn("required", title_input.attrs)
+
+                    url_input = soup.find("input", id="url")
+                    self.assertIsNotNone(url_input)
+                    self.assertIn("required", url_input.attrs)
+
+                    visibility_select = soup.find("select", id="visibility")
+                    self.assertIsNotNone(visibility_select)
+                    self.assertIn("required", visibility_select.attrs)
+
+                    options = visibility_select.find_all("option")
+                    self.assertEqual(len(options), 3)
+                    self.assertEqual(options[0].attrs["value"], "2")
+                    self.assertEqual(options[0].string, "Listed")
+                    self.assertEqual(options[1].attrs["value"], "1")
+                    self.assertEqual(options[1].string, "Unlisted")
+                    self.assertEqual(options[2].attrs["value"], "0")
+                    self.assertEqual(options[2].string, "Hidden")
+
+                    content_textarea = soup.find("textarea", id="content")
+                    self.assertIsNotNone(content_textarea)
+
+                    submit_button = soup.find("button", type="submit")
+                    self.assertIsNotNone(submit_button)
 
             self.clear_all_enrollments()
 

--- a/test/blueprints/test_course_blueprint.py
+++ b/test/blueprints/test_course_blueprint.py
@@ -449,14 +449,13 @@ This is the home page.
                 self.add_single_enrollment(enrollment)
 
                 response = self.test_client.post(course.starting_url_path + "/new/", data=sample_page_dictionary)
-                # FIXME switch to asserting by URL and course ID combo, not page ID
                 if role == Role.STUDENT:
                     self.assertEqual(response.status_code, 401)
-                    self.assert_single_page_does_not_exist_by_id(page_to_assert_against)
+                    self.assert_single_page_does_not_exist_by_course_id_and_url(page_to_assert_against)
                 else:
                     # Should redirect to the new page
                     self.assertEqual(response.status_code, 302)
-                    self.assert_single_page_against_matching_id_page_in_db(page_to_assert_against)
+                    self.assert_single_page_against_matching_course_id_and_url_in_db(page_to_assert_against)
 
             self.clear_all_enrollments()
 

--- a/test/blueprints/test_course_blueprint.py
+++ b/test/blueprints/test_course_blueprint.py
@@ -11,6 +11,8 @@ from models.user import User
 from test.test_flask_app import TestFlaskApp
 
 
+
+
 class TestCourseBlueprint(TestFlaskApp):
     static_page_content_for_testing = """
 # Home Page
@@ -29,6 +31,15 @@ This is the home page.
 - [Assignments](/assignments)
 - [Chapman Course Catalog](https://catalog.chapman.edu)
 """
+    def generate_sample_page_dictionary(self, course: Course):
+        return {
+            "page_title": "Office Hours",
+            "page_content": self.static_page_content_for_testing,
+            "page_visibility_setting": VisibilitySetting.LISTED.value,
+            "course_id": course.course_id,
+            "url_path_after_course_path": "/office-hours"
+        }
+
     def assert_course_layout_content(self, response: Response, course: Course, user: User, role: Optional[Role] = None):
         # Check reused layout content for the course
         # Future work:
@@ -422,13 +433,7 @@ This is the home page.
 
         # Note that values are passed as strings in form
         # even when defined as ints here
-        sample_page_dictionary = {
-            "page_title": "Office Hours",
-            "page_content": self.static_page_content_for_testing,
-            "page_visibility_setting": VisibilitySetting.LISTED.value,
-            "course_id": course.course_id,
-            "url_path_after_course_path": "/office-hours"
-        }
+        sample_page_dictionary = self.generate_sample_page_dictionary(course)
         page_to_assert_against = Page(**sample_page_dictionary)
 
         self.sign_user_into_session(user)
@@ -463,13 +468,7 @@ This is the home page.
 
         # Note that values are passed as strings in form
         # even when defined as ints here
-        sample_page_dictionary = {
-            "page_title": "Office Hours",
-            "page_content": self.static_page_content_for_testing,
-            "page_visibility_setting": VisibilitySetting.LISTED.value,
-            "course_id": course.course_id,
-            "url_path_after_course_path": "/office-hours"
-        }
+        sample_page_dictionary = self.generate_sample_page_dictionary(course)
         page_to_assert_against = Page(**sample_page_dictionary)
 
         # Insert the page first
@@ -490,10 +489,11 @@ This is the home page.
                 response = self.test_client.post(course.starting_url_path + "/new/", data=sample_page_dictionary)
                 if role == Role.STUDENT:
                     self.assertEqual(response.status_code, 401)
-                    self.assert_single_page_against_matching_id_page_in_db(page_to_assert_against)
                 else:
                     self.assertEqual(response.status_code, 400)
-                    self.assert_single_page_against_matching_id_page_in_db(page_to_assert_against)
+
+                # Page should remain unchanged
+                self.assert_single_page_against_matching_id_page_in_db(page_to_assert_against)
 
             self.clear_all_enrollments()
 

--- a/test/datarepos/test_content_repo.py
+++ b/test/datarepos/test_content_repo.py
@@ -47,43 +47,6 @@ Embark on your journey into the exciting world of game development today!
             created_by_user_id=created_by_user_id,
         )
 
-    def assert_single_page_against_matching_id_page_in_db(self, page_to_update):
-        get_page_query = '''
-        SELECT page.page_id,
-            page.course_id,
-            page.created_by_user_id,
-            page.page_content,
-            page.page_title,
-            page.page_visibility_setting,
-            page.url_path_after_course_path
-        FROM page
-        WHERE page.page_id = %s
-        '''
-        params = (page_to_update.page_id,)
-        cursor = self.connection.cursor(dictionary=True)
-        cursor.execute(get_page_query, params)
-        result = cursor.fetchone()
-        constructed_page = Page(**result)
-        self.assertEqual(constructed_page, page_to_update)
-
-    def assert_single_page_does_not_exist_by_id(self, nonexistent_page):
-        get_page_query = '''
-        SELECT page.page_id,
-            page.course_id,
-            page.created_by_user_id,
-            page.page_content,
-            page.page_title,
-            page.page_visibility_setting,
-            page.url_path_after_course_path
-        FROM page
-        WHERE page.page_id = %s
-        '''
-        params = (nonexistent_page.page_id,)
-        cursor = self.connection.cursor(dictionary=True)
-        cursor.execute(get_page_query, params)
-        result = cursor.fetchone()
-        self.assertIsNone(result)
-
     def test_add_new_page_and_get_id(self):
         # For a course to exist it must be linked to a course,
         # and it *may* be linked to a user

--- a/test/datarepos/test_course_repo.py
+++ b/test/datarepos/test_course_repo.py
@@ -185,14 +185,7 @@ class TestCourseRepo(TestWithDatabaseContainer):
                 expected_result = False if role == Role.STUDENT else True
                 self.assertEqual(result, expected_result)
 
-            # Regardless of whether test fails or succeeds,
-            # clear enrollments
-            delete_query = '''
-            DELETE FROM enrollment;
-            '''
-            cursor = self.connection.cursor()
-            cursor.execute(delete_query)
-            self.connection.commit()
+            self.clear_all_enrollments()
 
     def test_check_if_user_has_editing_rights_if_not_enrolled(self):
         user, _ = self.add_sample_user_to_test_db()
@@ -410,14 +403,7 @@ class TestCourseRepo(TestWithDatabaseContainer):
                 result = self.course_repo.get_user_role_in_class_if_exists(user.user_id, courses[0].course_id)
                 self.assertEqual(result, role)
 
-            # Regardless of whether test fails or succeeds,
-            # clear enrollments
-            delete_query = '''
-            DELETE FROM enrollment;
-            '''
-            cursor = self.connection.cursor()
-            cursor.execute(delete_query)
-            self.connection.commit()
+            self.clear_all_enrollments()
 
     def test_get_user_role_in_class_if_not_exists(self):
         user, _ = self.add_sample_user_to_test_db()

--- a/test/test_with_database_container.py
+++ b/test/test_with_database_container.py
@@ -233,3 +233,40 @@ class TestWithDatabaseContainer(unittest.TestCase):
         cursor = self.connection.cursor()
         cursor.execute(delete_query)
         self.connection.commit()
+
+    def assert_single_page_against_matching_id_page_in_db(self, page_to_update):
+        get_page_query = '''
+        SELECT page.page_id,
+            page.course_id,
+            page.created_by_user_id,
+            page.page_content,
+            page.page_title,
+            page.page_visibility_setting,
+            page.url_path_after_course_path
+        FROM page
+        WHERE page.page_id = %s
+        '''
+        params = (page_to_update.page_id,)
+        cursor = self.connection.cursor(dictionary=True)
+        cursor.execute(get_page_query, params)
+        result = cursor.fetchone()
+        constructed_page = Page(**result)
+        self.assertEqual(constructed_page, page_to_update)
+
+    def assert_single_page_does_not_exist_by_id(self, nonexistent_page):
+        get_page_query = '''
+        SELECT page.page_id,
+            page.course_id,
+            page.created_by_user_id,
+            page.page_content,
+            page.page_title,
+            page.page_visibility_setting,
+            page.url_path_after_course_path
+        FROM page
+        WHERE page.page_id = %s
+        '''
+        params = (nonexistent_page.page_id,)
+        cursor = self.connection.cursor(dictionary=True)
+        cursor.execute(get_page_query, params)
+        result = cursor.fetchone()
+        self.assertIsNone(result)

--- a/test/test_with_database_container.py
+++ b/test/test_with_database_container.py
@@ -253,6 +253,26 @@ class TestWithDatabaseContainer(unittest.TestCase):
         constructed_page = Page(**result)
         self.assertEqual(constructed_page, page_to_update)
 
+    def assert_single_page_against_matching_course_id_and_url_in_db(self, page_to_update: Page):
+        get_page_query = '''
+        SELECT page.page_id,
+            page.course_id,
+            page.created_by_user_id,
+            page.page_content,
+            page.page_title,
+            page.page_visibility_setting,
+            page.url_path_after_course_path
+        FROM page
+        WHERE page.course_id = %s
+            AND page.url_path_after_course_path = %s
+        '''
+        params = (page_to_update.course_id, page_to_update.url_path_after_course_path)
+        cursor = self.connection.cursor(dictionary=True)
+        cursor.execute(get_page_query, params)
+        result = cursor.fetchone()
+        constructed_page = Page(**result)
+        self.assertEqual(constructed_page, page_to_update)
+
     def assert_single_page_does_not_exist_by_id(self, nonexistent_page):
         get_page_query = '''
         SELECT page.page_id,
@@ -270,3 +290,23 @@ class TestWithDatabaseContainer(unittest.TestCase):
         cursor.execute(get_page_query, params)
         result = cursor.fetchone()
         self.assertIsNone(result)
+
+    def assert_single_page_does_not_exist_by_course_id_and_url(self, nonexistent_page: Page):
+        get_page_query = '''
+        SELECT page.page_id,
+            page.course_id,
+            page.created_by_user_id,
+            page.page_content,
+            page.page_title,
+            page.page_visibility_setting,
+            page.url_path_after_course_path
+        FROM page
+        WHERE page.course_id = %s
+            AND page.url_path_after_course_path = %s
+        '''
+        params = (nonexistent_page.course_id, nonexistent_page.url_path_after_course_path)
+        cursor = self.connection.cursor(dictionary=True)
+        cursor.execute(get_page_query, params)
+        result = cursor.fetchone()
+        self.assertIsNone(result)
+

--- a/test/test_with_database_container.py
+++ b/test/test_with_database_container.py
@@ -225,3 +225,11 @@ class TestWithDatabaseContainer(unittest.TestCase):
         self.connection.commit()
 
         return cursor.lastrowid
+
+    def clear_all_enrollments(self):
+        delete_query = '''
+        DELETE FROM enrollment;
+        '''
+        cursor = self.connection.cursor()
+        cursor.execute(delete_query)
+        self.connection.commit()

--- a/test/test_with_database_container.py
+++ b/test/test_with_database_container.py
@@ -234,6 +234,14 @@ class TestWithDatabaseContainer(unittest.TestCase):
         cursor.execute(delete_query)
         self.connection.commit()
 
+    def clear_all_pages(self):
+        delete_query = '''
+        DELETE FROM page;
+        '''
+        cursor = self.connection.cursor()
+        cursor.execute(delete_query)
+        self.connection.commit()
+
     def assert_single_page_against_matching_id_page_in_db(self, page_to_update):
         get_page_query = '''
         SELECT page.page_id,
@@ -253,7 +261,7 @@ class TestWithDatabaseContainer(unittest.TestCase):
         constructed_page = Page(**result)
         self.assertEqual(constructed_page, page_to_update)
 
-    def assert_single_page_against_matching_course_id_and_url_in_db(self, page_to_update: Page):
+    def assert_single_page_against_matching_course_id_and_url_in_db(self, page_to_update: Page, should_check_page_id = True):
         get_page_query = '''
         SELECT page.page_id,
             page.course_id,
@@ -270,7 +278,11 @@ class TestWithDatabaseContainer(unittest.TestCase):
         cursor = self.connection.cursor(dictionary=True)
         cursor.execute(get_page_query, params)
         result = cursor.fetchone()
+
         constructed_page = Page(**result)
+        if not should_check_page_id:
+            constructed_page.page_id = page_to_update.page_id
+
         self.assertEqual(constructed_page, page_to_update)
 
     def assert_single_page_does_not_exist_by_id(self, nonexistent_page):


### PR DESCRIPTION
- move methods from repo tests into database container test 
- add tests to course blueprint for page creation endpoint
- add tests for page creation UI
- add generator/callback execution methods to course blueprint
- render new page button for editors on sidebar
- render page editing interface with form submission